### PR TITLE
Monk X: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV PATH /opt/application/:$PATH
 ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
-    POETRY_VERSION=1.0.5
+    POETRY_VERSION=1.0.5 \
+    PYTHONSTACKSIZE=3000
 
 WORKDIR /opt/application/
 
@@ -16,7 +17,7 @@ RUN pip install "poetry==$POETRY_VERSION"
 RUN poetry config virtualenvs.create false
 COPY poetry.lock .
 COPY pyproject.toml  .
-RUN poetry install --no-dev --no-root
+RUN poetry install --no-root
 
 FROM python:3.8-slim as project
 COPY --from=build /usr/local/lib/python3.8/site-packages/ /usr/local/lib/python3.8/site-packages

--- a/simple-fastapi.yaml
+++ b/simple-fastapi.yaml
@@ -1,0 +1,57 @@
+namespace: simple-fastapi
+simple-fastapi:
+  defines: runnable
+  metadata:
+    name: simple-fastapi
+    description: A simple application based on FastAPI for Python backend development.
+    icon: https://emojiapi.dev/api/v1/snake.svg
+  containers:
+    simple-fastapi:
+      build: .
+      dockerfile: Dockerfile
+  services:
+    main:
+      container: simple-fastapi
+      port: <- $port
+      host-port: <- $port
+      publish: false
+      protocol: TCP
+      description: Main application port
+  connections:
+    database:
+      target: simple-fastapi/db
+      service: postgres
+  variables:
+    host:
+      env: HOST
+      type: string
+      description: The host IP
+      value: 0.0.0.0
+    port:
+      env: PORT
+      type: int
+      description: The port which the app runs
+      value: 8000
+    sentry-dsn:
+      env: SENTRY_DSN
+      type: string
+      description: Data Source Name for the Sentry application monitoring platform
+      value: '!!!SETME-USE-SECRETS!!!'
+    db-dsn:
+      env: DB_DSN
+      type: string
+      description: Database connection string
+      value: <- connection-hostname("database")
+    db-password:
+      env: DB_PASSWORD
+      type: string
+      description: Password for the database
+      value: '!!!SETME-USE-SECRETS!!!'
+db:
+  defines: runnable
+  inherits: postgresql/db
+stack:
+  defines: group
+  members:
+    - simple-fastapi/simple-fastapi
+    - simple-fastapi/db


### PR DESCRIPTION
I couldn't make the /tmp/xy7vb/Dockerfile work and gave up. You can try to fix it yourself. Here's the error I get:


```
Successfully built pyrsistent
Installing collected packages: webencodings, pylev, ptyprocess, lockfile, urllib3, tomlkit, six, shellingham, pyparsing, pycparser, pkginfo, pexpect, pastel, msgpack, jeepney, idna, charset-normalizer, certifi, cachy, attrs, requests, pyrsistent, html5lib, clikit, cffi, requests-toolbelt, jsonschema, cryptography, cleo, cachecontrol, secretstorage, keyring, poetry
Successfully installed attrs-23.1.0 cachecontrol-0.12.14 cachy-0.3.0 certifi-2023.7.22 cffi-1.16.0 charset-normalizer-3.3.2 cleo-0.7.6 clikit-0.4.3 cryptography-41.0.5 html5lib-1.1 idna-3.4 jeepney-0.8.0 jsonschema-3.2.0 keyring-20.0.1 lockfile-0.12.2 msgpack-1.0.7 pastel-0.2.1 pexpect-4.8.0 pkginfo-1.9.6 poetry-1.0.5 ptyprocess-0.7.0 pycparser-2.21 pylev-1.4.0 pyparsing-2.4.7 pyrsistent-0.14.11 requests-2.31.0 requests-toolbelt-0.8.0 secretstorage-3.3.3 shellingham-1.5.4 six-1.16.0 tomlkit-0.5.11 urllib3-2.0.7 webencodings-0.5.1
--> e71c28170fd
[1/2] STEP 10/13: RUN poetry config virtualenvs.create false
--> 52ee4e824b9
[1/2] STEP 11/13: COPY poetry.lock .
--> 5df6d2e8ef8
[1/2] STEP 12/13: COPY pyproject.toml  .
--> fb1959f1e27
[1/2] STEP 13/13: RUN poetry install --no-root
Skipping virtualenv creation, as specified in config file.
Installing dependencies from lock file
[RecursionError]
maximum recursion depth exceeded while calling a Python object
Failed to build image: image service build failed
Error chain: 
↪ image service build failed
 ↪ new job and wait failed
   (description: , name: job.images.build)
   ↪ build image failed
     (image: 134.122.112.216/simple-fastapi:master-90bf439)
     ↪ moby client build image: cmd wait failed
      ↪ WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Error: building at STEP "RUN poetry install --no-root": while running runtime: exit status 1

HINT If you did not expect this error, please share this code with Monk team:
      H4sIAAAAAAAC/7yS0U7bShCGX2W0NwSU2NhBnGTvOIhzoBJRFai4IFys7Ukywd5d7YyTRojbPkwfq09SrRMkoJXKVa8sa2f++f5/5v5JTd2Glb5/UtfIbBaotKLGLBAYw5pKhKKluoK5oRor1Vf/UR1remlwTlIf3ApLSf3jIt03cNr188t/snD6JI+drS2FnH2ZwEnv6GZXc5j8G6ccqr66RjGVEaO0Us/911jw49t3sLiBlSvA2Ao2huQjYCtXcNoK1RxZhqPjtzDxOZng5pMrzmx1Z0jecVTIZSAfyzX0wZoGdYRI9ja6hN7DdrS77HZ5fgC0MIwv6dVuQWXaCUTqf8ZvobvnpHe0csW5s2LIYvh9ip2ehmx4kmR5nmRZnuTZacrU+BoHc8NiPOnGsGAYjI+L+clw/IuZzk3jii2UNaGV1840lM3HlxFF0p1It418+NZYfE96R/Fz3lXtXV3FUX84kD3n3dl0cjX5X8O0tZbsAjx5MAyyRDiIQAfQMgYojYWA3NYCZKEI7hEteAwNMZOz3B1Z6ey8plKiToFLsybXBtiQLDs93rJgA96Uj3HJjbFmgSGBKwFiCFi6pkFbYQXi4lQwsKYgrakB7ZqCs02MkywLmkrDUsSzTlNPPvFbbxJy6caEaIPTNdr1zF6E4ILebSBSGYGb24vPMFPTLxPwDiVsO0FT1zAYWDeInmdKw2ZJNULYpxJaKxRPGb+SAIuRliGb2b+4voe+uiQrrLRt67qvutJLw0ul1XqYZHmSqb66pQZZTOOVzk7Ho9Hp8SgfPz/8DAAA//8Tti7rvQQAAA==


```

You can fix the error yourself, push to this branch and then merge the PR. Monk will import the kit ayutomatically.
Alternatively, just close the PR.